### PR TITLE
Fix: Nav links visibility on large screens and improve infinite scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 
                 <!-- Navigation Links -->
                 <div :class="{'nav-links-container': true, 'open': isNavOpen}"
-                     class="w-full lg:flex lg:items-center lg:w-auto mt-4 lg:mt-0 flex-col lg:flex-row space-y-3 lg:space-y-0 lg:space-x-8">
+                     class="w-full lg:flex lg:items-center lg:w-auto mt-4 lg:mt-0 flex-col lg:flex-row space-y-3 lg:space-y-0 lg:space-x-8 lg:max-h-none lg:overflow-visible">
                     <a href="#" @click.prevent="currentPage = 'home'; isNavOpen = false;" class="text-white hover:text-purple-200 text-lg font-medium py-2 px-3 rounded-md transition-colors duration-200">Home</a>
                     <a href="#" @click.prevent="currentPage = 'discover'; isNavOpen = false;" class="text-white hover:text-purple-200 text-lg font-medium py-2 px-3 rounded-md transition-colors duration-200">Discover Projects</a>
                     <a href="#" @click.prevent="currentPage = 'startProject'; isNavOpen = false;" class="text-white hover:text-purple-200 text-lg font-medium py-2 px-3 rounded-md transition-colors duration-200">Submit Your Project</a>
@@ -596,8 +596,10 @@
                         // jump back to the beginning of the second set for seamless looping.
                         // The total scrollable width is 3x the original content width.
                         // We reset when we pass the width of one original set.
-                        if (showcase.scrollLeft >= originalContentWidth) {
-                            showcase.scrollLeft = 0; // Reset to the beginning of the "next" cycle
+                    if (showcase.scrollLeft >= 2 * originalContentWidth) {
+                        // Jump back to the start of the second set to make the loop seamless
+                        // using the second set as the primary repeating block.
+                        showcase.scrollLeft = originalContentWidth;
                         }
                     }, 20); // Adjust interval for desired speed (lower value = faster, smoother)
                 },


### PR DESCRIPTION
- Ensure navigation links are visible on large screens by overriding max-height and overflow properties applied for mobile view.
- Update the infinite scroll logic for featured projects to use a 3-set buffer more effectively, resetting scroll from the start of the 3rd set to the start of the 2nd set for a smoother loop.